### PR TITLE
Enable running all enabled tests and examples on a single GPU with multiple MPI ranks

### DIFF
--- a/examples/cc/basic_usage/basic_usage_autotune.cc
+++ b/examples/cc/basic_usage/basic_usage_autotune.cc
@@ -107,6 +107,11 @@ int main(int argc, char** argv) {
   CHECK_HIP_EXIT(hipGetDeviceCount(&device_count));
   CHECK_HIP_EXIT(hipSetDevice(local_rank % device_count));
 
+  // Cannot use NCCL if multiple ranks run on the same GPU
+  bool disable_nccl_backends = false;
+  if (local_rank >= device_count) disable_nccl_backends = true;
+  CHECK_MPI_EXIT(MPI_Allreduce(MPI_IN_PLACE, &disable_nccl_backends, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD));
+
   hipdecompHandle_t handle;
   CHECK_HIPDECOMP_EXIT(hipdecompInit(&handle, MPI_COMM_WORLD));
 
@@ -134,7 +139,7 @@ int main(int argc, char** argv) {
   options.n_warmup_trials = 3;
   options.n_trials = 5;
   options.dtype = HIPDECOMP_DOUBLE;
-  options.disable_nccl_backends = false;
+  options.disable_nccl_backends = disable_nccl_backends;
   options.disable_nvshmem_backends = false;
   options.skip_threshold = 0.0;
 

--- a/examples/cc/taylor_green/tg.cc
+++ b/examples/cc/taylor_green/tg.cc
@@ -351,6 +351,11 @@ public:
     CHECK_HIP_EXIT(hipGetDeviceCount(&device_count));
     CHECK_HIP_EXIT(hipSetDevice(local_rank % device_count));
 
+    // Cannot use NCCL if multiple ranks run on the same GPU
+    bool disable_nccl_backends = false;
+    if (local_rank >= device_count) disable_nccl_backends = true;
+    CHECK_MPI_EXIT(MPI_Allreduce(MPI_IN_PLACE, &disable_nccl_backends, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD));
+
     if (rank == 0) printf("running on %d x %d x %d spatial grid...\n", (int)N, (int)N, (int)N);
 
     // Initialize hipDecomp
@@ -368,6 +373,7 @@ public:
     hipdecompGridDescAutotuneOptions_t options;
     hipdecompGridDescAutotuneOptionsSetDefaults(&options);
     options.dtype = get_hipdecomp_datatype(complex_t(0));
+    options.disable_nccl_backends = disable_nccl_backends;
     options.autotune_transpose_backend = true;
 
     std::array<int, 3> gdim_c{(int)N / 2 + 1, (int)N, (int)N};

--- a/tests/cc/halo_test.cc
+++ b/tests/cc/halo_test.cc
@@ -345,7 +345,7 @@ static void cache_grid_desc(const hipdecompGridDesc_t& grid_desc, hipdecompHaloC
   grid_desc_cache[backend] = grid_desc;
 }
 
-static int run_test(const std::string& arguments, bool silent) {
+static int run_test(const std::string& arguments, bool silent, bool disable_nccl_backends) {
   try {
     haloTestArgs args = parse_arguments(arguments);
 
@@ -387,6 +387,7 @@ static int run_test(const std::string& arguments, bool silent) {
     options.halo_periods[2] = args.halo_periods[2];
     options.halo_axis = args.axis;
     options.dtype = get_hipdecomp_datatype(real_t(0));
+    options.disable_nccl_backends = disable_nccl_backends;
     options.grid_mode = HIPDECOMP_AUTOTUNE_GRID_HALO;
 
     if (args.comm_backend != 0) {
@@ -510,6 +511,11 @@ int main(int argc, char** argv) {
   CHECK_HIP_EXIT(hipGetDeviceCount(&device_count));
   CHECK_HIP_EXIT(hipSetDevice(local_rank % device_count));
 
+  // Cannot use NCCL if multiple ranks run on the same GPU
+  bool disable_nccl_backends = false;
+  if (local_rank >= device_count) disable_nccl_backends = true;
+  CHECK_MPI_EXIT(MPI_Allreduce(MPI_IN_PLACE, &disable_nccl_backends, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD));
+
   // Check if test file was provided
   std::string testfile;
   bool using_testfile = false;
@@ -541,7 +547,7 @@ int main(int argc, char** argv) {
   if (using_testfile && rank == 0) printf("Running %d tests...\n", static_cast<int>(testcases.size()));
   for (int i = 0; i < testcases.size(); ++i) {
     if (using_testfile && rank == 0) printf("command: %s %s\n", argv[0], testcases[i].c_str());
-    int res = run_test(testcases[i], using_testfile);
+    int res = run_test(testcases[i], using_testfile, disable_nccl_backends);
     CHECK_MPI_EXIT(MPI_Reduce((rank == 0) ? MPI_IN_PLACE : &res, &res, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD));
     if (using_testfile && rank == 0) {
       if (res != 0) {

--- a/tests/cc/transpose_test.cc
+++ b/tests/cc/transpose_test.cc
@@ -364,7 +364,7 @@ static void cache_grid_desc(const hipdecompGridDesc_t& grid_desc, hipdecompTrans
   grid_desc_cache[backend] = grid_desc;
 }
 
-static int run_test(const std::string& arguments, bool silent) {
+static int run_test(const std::string& arguments, bool silent, bool disable_nccl_backends) {
   try {
     transposeTestArgs args = parse_arguments(arguments);
 
@@ -399,6 +399,7 @@ static int run_test(const std::string& arguments, bool silent) {
     hipdecompGridDescAutotuneOptions_t options;
     CHECK_HIPDECOMP(hipdecompGridDescAutotuneOptionsSetDefaults(&options));
     options.dtype = get_hipdecomp_datatype(real_t(0));
+    options.disable_nccl_backends = disable_nccl_backends;
     for (int i = 0; i < 4; ++i) {
       options.transpose_use_inplace_buffers[i] = !args.out_of_place;
     }
@@ -574,6 +575,11 @@ int main(int argc, char** argv) {
   CHECK_HIP_EXIT(hipGetDeviceCount(&device_count));
   CHECK_HIP_EXIT(hipSetDevice(local_rank % device_count));
 
+  // Cannot use NCCL if multiple ranks run on the same GPU
+  bool disable_nccl_backends = false;
+  if (local_rank >= device_count) disable_nccl_backends = true;
+  CHECK_MPI_EXIT(MPI_Allreduce(MPI_IN_PLACE, &disable_nccl_backends, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD));
+
   // Check if test file was provided
   std::string testfile;
   bool using_testfile = false;
@@ -605,7 +611,7 @@ int main(int argc, char** argv) {
   if (using_testfile && rank == 0) printf("Running %d tests...\n", static_cast<int>(testcases.size()));
   for (int i = 0; i < testcases.size(); ++i) {
     if (using_testfile && rank == 0) printf("command: %s %s\n", argv[0], testcases[i].c_str());
-    int res = run_test(testcases[i], using_testfile);
+    int res = run_test(testcases[i], using_testfile, disable_nccl_backends);
     CHECK_MPI_EXIT(MPI_Reduce((rank == 0) ? MPI_IN_PLACE : &res, &res, 1, MPI_INT, MPI_MAX, 0, MPI_COMM_WORLD));
     if (using_testfile && rank == 0) {
       if (res != 0) {

--- a/tests/fortran/halo_test.f90
+++ b/tests/fortran/halo_test.f90
@@ -46,13 +46,14 @@ module halo_HIPDECOMP_DOUBLE_COMPLEX_mod
 #endif
 
   use, intrinsic :: iso_fortran_env, only: real32, real64
-  use hipfort, only: hipFree,hipMalloc,hipMallocManaged,hipSuccess,hipSetDevice
+  use hipfort, only: hipFree,hipGetDeviceCount,hipMalloc,hipMallocManaged,hipSuccess,hipSetDevice
   use hipfort_types, only: hipMemAttachGlobal
   use hipdecomp
   use mpi
 
   type(hipdecompHandle) :: handle
   integer :: rank, nranks
+  logical :: disable_nccl_backends
   type(hipdecompGridDesc) :: grid_desc_cache(5)
   logical :: grid_desc_cache_set(5) = .false.
   ARRTYPE, pointer, contiguous :: work_d(:)
@@ -425,6 +426,7 @@ module halo_HIPDECOMP_DOUBLE_COMPLEX_mod
     options%halo_periods = halo_periods
     options%halo_axis = axis
     options%dtype = dtype
+    options%disable_nccl_backends = disable_nccl_backends
     options%grid_mode = HIPDECOMP_AUTOTUNE_GRID_HALO
 
     if (comm_backend /= 0) then
@@ -546,7 +548,7 @@ program main
   integer :: i, idx
   real(real64) :: t0
   integer :: local_rank, ierr
-  integer :: local_comm
+  integer :: local_comm, device_count
   integer :: res, retcode
   logical :: using_testfile
   character(len=16) :: arg
@@ -562,7 +564,14 @@ program main
 
   call MPI_Comm_split_Type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, local_comm, ierr)
   call MPI_Comm_rank(local_comm, local_rank, ierr)
-  CHECK_HIP_EXIT(hipSetDevice(local_rank))
+
+  CHECK_HIP_EXIT(hipGetDeviceCount(device_count))
+  CHECK_HIP_EXIT(hipSetDevice(mod(local_rank, device_count)))
+
+  ! Cannot use NCCL if multiple ranks run on the same GPU
+  disable_nccl_backends = .false.
+  if (local_rank >= device_count) disable_nccl_backends = .true.
+  call MPI_Allreduce(MPI_IN_PLACE, disable_nccl_backends, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierr)
 
   using_testfile = .false.
   do i = 1, command_argument_count()

--- a/tests/fortran/transpose_test.f90
+++ b/tests/fortran/transpose_test.f90
@@ -46,13 +46,14 @@ module transpose_HIPDECOMP_DOUBLE_COMPLEX_mod
 #endif
 
   use, intrinsic :: iso_fortran_env, only: real32, real64
-  use hipfort, only : hipFree,hipMalloc,hipMallocManaged,hipSuccess,hipSetDevice
+  use hipfort, only : hipFree,hipGetDeviceCount,hipMalloc,hipMallocManaged,hipSuccess,hipSetDevice
   use hipfort_types, only: hipMemAttachGlobal
   use hipdecomp
   use mpi
 
   type(hipdecompHandle) :: handle
   integer :: rank, nranks
+  logical :: disable_nccl_backends
   type(hipdecompGridDesc) :: grid_desc_cache(7)
   logical :: grid_desc_cache_set(7) = .false.
   ARRTYPE, pointer, contiguous :: work_d(:)
@@ -378,6 +379,7 @@ module transpose_HIPDECOMP_DOUBLE_COMPLEX_mod
 
     CHECK_HIPDECOMP(hipdecompGridDescAutotuneOptionsSetDefaults(options))
     options%dtype = dtype
+    options%disable_nccl_backends = disable_nccl_backends
     options%transpose_use_inplace_buffers = .not. out_of_place
 
     if (comm_backend /= 0) then
@@ -570,7 +572,7 @@ program main
   integer :: i, idx
   real(real64) :: t0
   integer :: local_rank, ierr
-  integer :: local_comm
+  integer :: local_comm, device_count
   integer :: res, retcode
   logical :: using_testfile
   character(len=16) :: arg
@@ -586,7 +588,14 @@ program main
 
   call MPI_Comm_split_Type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, local_comm, ierr)
   call MPI_Comm_rank(local_comm, local_rank, ierr)
-  CHECK_HIP_EXIT(hipSetDevice(local_rank))
+
+  CHECK_HIP_EXIT(hipGetDeviceCount(device_count))
+  CHECK_HIP_EXIT(hipSetDevice(mod(local_rank, device_count)))
+
+  ! Cannot use NCCL if multiple ranks run on the same GPU
+  disable_nccl_backends = .false.
+  if (local_rank >= device_count) disable_nccl_backends = .true.
+  call MPI_Allreduce(MPI_IN_PLACE, disable_nccl_backends, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierr)
 
   using_testfile = .false.
   do i = 1, command_argument_count()


### PR DESCRIPTION
Achieved by
1. Setting the device to `local_rank % device_count`
2. Disabling the NCCL backend when multiple ranks run on the same GPU (not supported by NCCL)