### PR TITLE
Trick hipTensor into handling non-float types for permutations.

### DIFF
--- a/examples/fortran/basic_usage/basic_usage.f90
+++ b/examples/fortran/basic_usage/basic_usage.f90
@@ -37,7 +37,7 @@ program main
   use hipfort
   use mpi
   use hipdecomp
-  use, intrinsic :: iso_fortran_env, only: real32
+  use, intrinsic :: iso_fortran_env, only: real64
 
   implicit none
 
@@ -54,11 +54,11 @@ program main
   integer :: istat
 
   ! data
-  real(real32), allocatable, target :: data(:)
-  real(real32), pointer :: data_d(:)
-  real(real32), pointer, contiguous :: transpose_work_d(:), halo_work_d(:)
-  real(real32), pointer, contiguous :: data_x(:,:,:), data_y(:,:,:), data_z(:,:,:)
-  real(real32), pointer :: data_x_d(:,:,:), data_y_d(:,:,:), data_z_d(:,:,:)
+  real(real64), allocatable, target :: data(:)
+  real(real64), pointer :: data_d(:)
+  real(real64), pointer, contiguous :: transpose_work_d(:), halo_work_d(:)
+  real(real64), pointer, contiguous :: data_x(:,:,:), data_y(:,:,:), data_z(:,:,:)
+  real(real64), pointer :: data_x_d(:,:,:), data_y_d(:,:,:), data_z_d(:,:,:)
   integer(8) :: data_num_elements, transpose_work_num_elements, halo_work_num_elements
   logical :: halo_periods(3)
 
@@ -206,7 +206,7 @@ program main
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Allocate using hipdecompMalloc
-  ! Note: *_work_d arrays are of type consistent with hipdecompDataType to be used (HIPDECOMP_FLOAT). Otherwise,
+  ! Note: *_work_d arrays are of type consistent with hipdecompDataType to be used (HIPDECOMP_DOUBLE). Otherwise,
   ! must adjust workspace_num_elements to allocate enough workspace.
   istat = hipdecompMalloc(handle, grid_desc, transpose_work_d, transpose_work_num_elements)
   call CHECK_HIPDECOMP_EXIT(istat)
@@ -216,19 +216,19 @@ program main
   ! Transposing data
 
   ! Transpose from X-pencils to Y-pencils.
-  istat = hipdecompTransposeXToY(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_FLOAT, pinfo_x%halo_extents, [0,0,0])
+  istat = hipdecompTransposeXToY(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_DOUBLE, pinfo_x%halo_extents, [0,0,0])
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Transpose from Y-pencils to Z-pencils.
-  istat = hipdecompTransposeYToZ(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_FLOAT)
+  istat = hipdecompTransposeYToZ(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_DOUBLE)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Transpose from Z-pencils to Y-pencils.
-  istat = hipdecompTransposeZToY(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_FLOAT)
+  istat = hipdecompTransposeZToY(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_DOUBLE)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Transpose from Y-pencils to X-pencils.
-  istat = hipdecompTransposeYToX(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_FLOAT, [0,0,0], pinfo_x%halo_extents)
+  istat = hipdecompTransposeYToX(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_DOUBLE, [0,0,0], pinfo_x%halo_extents)
   call CHECK_HIPDECOMP_EXIT(istat)
 
 
@@ -238,15 +238,15 @@ program main
   halo_periods = [.true., .true., .true.]
 
   ! Update X-pencil halos in X direction
-  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_FLOAT, pinfo_x%halo_extents, halo_periods, 1)
+  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_DOUBLE, pinfo_x%halo_extents, halo_periods, 1)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Update X-pencil halos in Y direction
-  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_FLOAT, pinfo_x%halo_extents, halo_periods, 2)
+  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_DOUBLE, pinfo_x%halo_extents, halo_periods, 2)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Update X-pencil halos in Z direction
-  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_FLOAT, pinfo_x%halo_extents, halo_periods, 3)
+  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_DOUBLE, pinfo_x%halo_extents, halo_periods, 3)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Cleanup resources

--- a/examples/fortran/basic_usage/basic_usage_autotune.f90
+++ b/examples/fortran/basic_usage/basic_usage_autotune.f90
@@ -37,7 +37,7 @@ program main
   use hipfort
   use mpi
   use hipdecomp
-  use, intrinsic :: iso_fortran_env, only: real32
+  use, intrinsic :: iso_fortran_env, only: real64
 
   implicit none
 
@@ -55,11 +55,11 @@ program main
   logical :: disable_nccl_backends
 
   ! data
-  real(real32), allocatable, target :: data(:)
-  real(real32), pointer :: data_d(:)
-  real(real32), pointer, contiguous :: transpose_work_d(:), halo_work_d(:)
-  real(real32), pointer, contiguous :: data_x(:,:,:), data_y(:,:,:), data_z(:,:,:)
-  real(real32), pointer :: data_x_d(:,:,:), data_y_d(:,:,:), data_z_d(:,:,:)
+  real(real64), allocatable, target :: data(:)
+  real(real64), pointer :: data_d(:)
+  real(real64), pointer, contiguous :: transpose_work_d(:), halo_work_d(:)
+  real(real64), pointer, contiguous :: data_x(:,:,:), data_y(:,:,:), data_z(:,:,:)
+  real(real64), pointer :: data_x_d(:,:,:), data_y_d(:,:,:), data_z_d(:,:,:)
   integer(8) :: data_num_elements, transpose_work_num_elements, halo_work_num_elements
   logical :: halo_periods(3)
 
@@ -104,7 +104,7 @@ program main
   ! General options
   options%n_warmup_trials = 3
   options%n_trials = 5
-  options%dtype = HIPDECOMP_FLOAT
+  options%dtype = HIPDECOMP_DOUBLE
   options%disable_nccl_backends = disable_nccl_backends
   options%disable_nvshmem_backends = .false.
   options%skip_threshold = 0.0
@@ -247,7 +247,7 @@ program main
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Allocate using hipdecompMalloc
-  ! Note: *_work_d arrays are of type consistent with hipdecompDataType to be used (HIPDECOMP_FLOAT). Otherwise,
+  ! Note: *_work_d arrays are of type consistent with hipdecompDataType to be used (HIPDECOMP_DOUBLE). Otherwise,
   ! must adjust workspace_num_elements to allocate enough workspace.
   istat = hipdecompMalloc(handle, grid_desc, transpose_work_d, transpose_work_num_elements)
   call CHECK_HIPDECOMP_EXIT(istat)
@@ -257,19 +257,19 @@ program main
   ! Transposing data
 
   ! Transpose from X-pencils to Y-pencils.
-  istat = hipdecompTransposeXToY(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_FLOAT, pinfo_x%halo_extents, [0,0,0])
+  istat = hipdecompTransposeXToY(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_DOUBLE, pinfo_x%halo_extents, [0,0,0])
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Transpose from Y-pencils to Z-pencils.
-  istat = hipdecompTransposeYToZ(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_FLOAT)
+  istat = hipdecompTransposeYToZ(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_DOUBLE)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Transpose from Z-pencils to Y-pencils.
-  istat = hipdecompTransposeZToY(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_FLOAT)
+  istat = hipdecompTransposeZToY(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_DOUBLE)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Transpose from Y-pencils to X-pencils.
-  istat = hipdecompTransposeYToX(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_FLOAT, [0,0,0], pinfo_x%halo_extents)
+  istat = hipdecompTransposeYToX(handle, grid_desc, data_d, data_d, transpose_work_d, HIPDECOMP_DOUBLE, [0,0,0], pinfo_x%halo_extents)
   call CHECK_HIPDECOMP_EXIT(istat)
 
 
@@ -279,15 +279,15 @@ program main
   halo_periods = [.true., .true., .true.]
 
   ! Update X-pencil halos in X direction
-  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_FLOAT, pinfo_x%halo_extents, halo_periods, 1)
+  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_DOUBLE, pinfo_x%halo_extents, halo_periods, 1)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Update X-pencil halos in Y direction
-  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_FLOAT, pinfo_x%halo_extents, halo_periods, 2)
+  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_DOUBLE, pinfo_x%halo_extents, halo_periods, 2)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Update X-pencil halos in Z direction
-  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_FLOAT, pinfo_x%halo_extents, halo_periods, 3)
+  istat = hipdecompUpdateHalosX(handle, grid_desc, data_d, halo_work_d, HIPDECOMP_DOUBLE, pinfo_x%halo_extents, halo_periods, 3)
   call CHECK_HIPDECOMP_EXIT(istat)
 
   ! Cleanup resources

--- a/include/internal/checks.h
+++ b/include/internal/checks.h
@@ -25,7 +25,6 @@
 
 #include <hip/hip_runtime.h>
 #include <hipfft/hipfft.h>
-// ToDo: select hiptensor header through CMake
 #if HIP_VERSION_MAJOR < 7
 #include <hiptensor/hiptensor.hpp>
 #else

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -415,6 +415,10 @@ template <typename T> static inline bool anyNonzeros(const std::array<T, 3>& arr
   return (arr[0] != T(0) || arr[1] != T(0) || arr[2] != T(0));
 }
 
+template <typename T> static inline bool anyNonzeros(const std::array<T, 4>& arr) {
+  return (arr[0] != T(0) || arr[1] != T(0) || arr[2] != T(0) || arr[3] != T(0));
+}
+
 // Assigns an integer ID to every unique value in a vector
 template <typename T> std::unordered_map<T, unsigned int> getUniqueIds(const std::vector<T>& v) {
   std::unordered_map<T, unsigned int> ids;

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -21,12 +21,10 @@
 
 #include <array>
 #include <cstdint>
-#include <iostream>
 #include <vector>
 
 #include <complex>
 #include <hip/hip_runtime.h>
-// ToDo: select hiptensor header through CMake
 #if HIP_VERSION_MAJOR < 7
 #include <hiptensor/hiptensor.hpp>
 #else

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <cstdint>
+#include <iostream>
 #include <vector>
 
 #include <complex>
@@ -79,28 +80,44 @@ template <typename T>
 static void localPermute(const hipdecompHandle_t handle, const std::array<int64_t, 3>& extent_in,
                          const std::array<int32_t, 3>& order_out, const std::array<int64_t, 3>& strides_in,
                          const std::array<int64_t, 3>& strides_out, T* input, T* output, hipStream_t stream) {
-  hiptensorDataType_t hiptensor_type = getHiptensorDataType<T>();
+  // hipTensor only supports float for permutations
+  // handle this by adding an axis to the tensor that stays in place
+  // hiptensorDataType_t hiptensor_type = getHiptensorDataType<T>();
+  hiptensorDataType_t hiptensor_type = getHiptensorDataType<float>();
 
-  std::array<int32_t, 3> order_in{0, 1, 2};
-  std::array<int64_t, 3> extent_out;
+  std::array<int32_t, 4> order_in{0, 1, 2, 3};
+  std::array<int32_t, 4> order_out_;
+  std::array<int64_t, 4> extent_in_;
+  std::array<int64_t, 4> extent_out;
+  std::array<int64_t, 4> strides_in_;
+  std::array<int64_t, 4> strides_out_;
   for (int i = 0; i < 3; ++i) {
     extent_out[i] = extent_in[order_out[i]];
     if (extent_out[i] == 0) return;
+    extent_in_[i] = extent_in[i];
+    order_out_[i] = order_out[i];
+    strides_in_[i] = strides_in[i];
+    strides_out_[i] = strides_out[i];
   }
+  extent_out[3] = sizeof(T) / sizeof(float);
+  extent_in_[3] = sizeof(T) / sizeof(float);
+  order_out_[3] = order_in[3];
+  strides_in_[3] = 0;
+  strides_out_[3] = 0;
 
-  auto strides_in_ptr = anyNonzeros(strides_in) ? strides_in.data() : nullptr;
-  auto strides_out_ptr = anyNonzeros(strides_out) ? strides_out.data() : nullptr;
+  auto strides_in_ptr = anyNonzeros(strides_in_) ? strides_in_.data() : nullptr;
+  auto strides_out_ptr = anyNonzeros(strides_out_) ? strides_out_.data() : nullptr;
 
   hiptensorTensorDescriptor_t desc_in;
-  CHECK_HIPTENSOR(hiptensorCreateTensorDescriptor(handle->hiptensor_handle, &desc_in, 3, extent_in.data(),
+  CHECK_HIPTENSOR(hiptensorCreateTensorDescriptor(handle->hiptensor_handle, &desc_in, 4, extent_in_.data(),
                                                   strides_in_ptr, hiptensor_type, getAlignment(input)));
   hiptensorTensorDescriptor_t desc_out;
-  CHECK_HIPTENSOR(hiptensorCreateTensorDescriptor(handle->hiptensor_handle, &desc_out, 3, extent_out.data(),
+  CHECK_HIPTENSOR(hiptensorCreateTensorDescriptor(handle->hiptensor_handle, &desc_out, 4, extent_out.data(),
                                                   strides_out_ptr, hiptensor_type, getAlignment(output)));
 
   hiptensorOperationDescriptor_t desc_op;
   CHECK_HIPTENSOR(hiptensorCreatePermutation(handle->hiptensor_handle, &desc_op, desc_in, order_in.data(),
-                                             HIPTENSOR_OP_IDENTITY, desc_out, order_out.data(),
+                                             HIPTENSOR_OP_IDENTITY, desc_out, order_out_.data(),
                                              getHiptensorComputeType(hiptensor_type)));
 
   hiptensorPlan_t plan;
@@ -127,21 +144,37 @@ template <typename T>
 static void localPermute(const hipdecompHandle_t handle, const std::array<int64_t, 3>& extent_in,
                          const std::array<int32_t, 3>& order_out, const std::array<int64_t, 3>& strides_in,
                          const std::array<int64_t, 3>& strides_out, T* input, T* output, hipStream_t stream) {
-  hipDataType hip_type = getHipDataType<T>();
+  // hipTensor only supports float for permutations
+  // handle this by adding an axis to the tensor that stays in place
+  // hipDataType hip_type = getHipDataType<T>();
+  hipDataType hip_type = getHipDataType<float>();
 
-  std::array<int32_t, 3> order_in{0, 1, 2};
-  std::array<int64_t, 3> extent_out;
+  std::array<int32_t, 4> order_in{0, 1, 2, 3};
+  std::array<int32_t, 4> order_out_;
+  std::array<int64_t, 4> extent_in_;
+  std::array<int64_t, 4> extent_out;
+  std::array<int64_t, 4> strides_in_;
+  std::array<int64_t, 4> strides_out_;
   for (int i = 0; i < 3; ++i) {
     extent_out[i] = extent_in[order_out[i]];
     if (extent_out[i] == 0) return;
+    extent_in_[i] = extent_in[i];
+    order_out_[i] = order_out[i];
+    strides_in_[i] = strides_in[i];
+    strides_out_[i] = strides_out[i];
   }
+  extent_out[3] = sizeof(T) / sizeof(float);
+  extent_in_[3] = sizeof(T) / sizeof(float);
+  order_out_[3] = order_in[3];
+  strides_in_[3] = 0;
+  strides_out_[3] = 0;
 
-  auto strides_in_ptr = anyNonzeros(strides_in) ? strides_in.data() : nullptr;
-  auto strides_out_ptr = anyNonzeros(strides_out) ? strides_out.data() : nullptr;
+  auto strides_in_ptr = anyNonzeros(strides_in_) ? strides_in_.data() : nullptr;
+  auto strides_out_ptr = anyNonzeros(strides_out_) ? strides_out_.data() : nullptr;
 
   hiptensorTensorDescriptor_t desc_in;
-  CHECK_HIPTENSOR(hiptensorInitTensorDescriptor(handle->hiptensor_handle, &desc_in, 3, extent_in.data(), strides_in_ptr,
-                                                hip_type, HIPTENSOR_OP_IDENTITY));
+  CHECK_HIPTENSOR(hiptensorInitTensorDescriptor(handle->hiptensor_handle, &desc_in, 3, extent_in_.data(),
+                                                strides_in_ptr, hip_type, HIPTENSOR_OP_IDENTITY));
 
   hiptensorTensorDescriptor_t desc_out;
   CHECK_HIPTENSOR(hiptensorInitTensorDescriptor(handle->hiptensor_handle, &desc_out, 3, extent_out.data(),
@@ -149,7 +182,7 @@ static void localPermute(const hipdecompHandle_t handle, const std::array<int64_
 
   T one(1);
   CHECK_HIPTENSOR(hiptensorPermutation(handle->hiptensor_handle, &one, input, &desc_in, order_in.data(), output,
-                                       &desc_out, order_out.data(), hip_type, stream));
+                                       &desc_out, order_out_.data(), hip_type, stream));
 }
 #endif
 


### PR DESCRIPTION
hipTensor can only do float for a permutation. We handle this by adding an extra tensor axis with size sizeof(T) / sizeof(float), which stays in place.

The examples that were converted to single precision are converted back to double.