### PR TITLE
Replace hipTensor by custom kernel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: loostrum/rocm-installer@v0.2
         with:
           version: ${{ env.rocm-version }}
-          packages: rocm-hip-runtime-dev hipcub-dev hipfft-dev hipfort-dev hiptensor-dev rccl-dev rocprofiler-sdk-roctx
+          packages: rocm-hip-runtime-dev hipcub-dev hipfft-dev hipfort-dev rccl-dev rocprofiler-sdk-roctx
 
       - name: Install OpenMPI
         if: steps.cache-openmpi.outputs.cache-hit != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,6 @@ endif()
 # Get RCCL library
 find_package(rccl REQUIRED)
 
-# Get hipTensor library
-find_package(hiptensor REQUIRED)
-
 if (HIPDECOMP_ENABLE_ROCSHMEM)
   # Get ROCSHMEM library
   find_package(rocshmem REQUIRED)
@@ -117,7 +114,6 @@ target_include_directories(hipdecomp
 
 target_link_libraries(hipdecomp PUBLIC hip::host hip::device)
 target_link_libraries(hipdecomp PUBLIC MPI::MPI_CXX)
-target_link_libraries(hipdecomp PRIVATE hiptensor)
 target_link_libraries(hipdecomp PRIVATE rccl)
 if (HIPDECOMP_ENABLE_ROCTX)
   target_link_libraries(hipdecomp PRIVATE rocprofiler-sdk-roctx)

--- a/examples/cc/basic_usage/CMakeLists.txt
+++ b/examples/cc/basic_usage/CMakeLists.txt
@@ -26,7 +26,6 @@ foreach(tgt ${basic_usage_targets_cc})
   )
   target_link_libraries(${tgt} PRIVATE MPI::MPI_CXX)
   target_link_libraries(${tgt} PRIVATE hipdecomp)
-  target_link_libraries(${tgt} PRIVATE hiptensor)
   set_target_properties(${tgt} PROPERTIES LINKER_LANGUAGE CXX)
 endforeach()
 

--- a/examples/cc/basic_usage/basic_usage_autotune.cc
+++ b/examples/cc/basic_usage/basic_usage_autotune.cc
@@ -27,7 +27,6 @@
 #include <mpi.h>
 
 #include <hip/hip_runtime.h>
-#include <hiptensor/hiptensor.hpp>
 
 #include "hipdecomp.h"
 
@@ -90,8 +89,6 @@ __global__ void initialize_pencil(double* data, hipdecompPencilInfo_t pinfo) {
 }
 
 int main(int argc, char** argv) {
-  hiptensorLoggerSetLevel(HIPTENSOR_LOG_LEVEL_ERROR);
-
   // Initialize MPI and start up hipDecomp
   CHECK_MPI_EXIT(MPI_Init(nullptr, nullptr));
   int rank, nranks;

--- a/include/hipdecomp.h
+++ b/include/hipdecomp.h
@@ -86,15 +86,16 @@ typedef enum {
  * will return one of these values to indicate if an operation has completed successfully or an error occured.
  */
 typedef enum {
-  HIPDECOMP_RESULT_SUCCESS = 0,         ///< The operation completed successfully
-  HIPDECOMP_RESULT_INVALID_USAGE = 1,   ///< A user error, typically an invalid argument
-  HIPDECOMP_RESULT_NOT_SUPPORTED = 2,   ///< A user error, requesting an invalid or unsupported operation configuration
-  HIPDECOMP_RESULT_INTERNAL_ERROR = 3,  ///< An internal library error, should be reported
-  HIPDECOMP_RESULT_HIP_ERROR = 4,       ///< An error occured in the HIP Runtime
-  HIPDECOMP_RESULT_HIPTENSOR_ERROR = 5, ///< An error occured in the hipTENSOR library
-  HIPDECOMP_RESULT_MPI_ERROR = 6,       ///< An error occurred in the MPI library
-  HIPDECOMP_RESULT_NCCL_ERROR = 7,      ///< An error occured in the NCCL library
-  HIPDECOMP_RESULT_NVSHMEM_ERROR = 8,   ///< An error occured in the NVSHMEM library
+  HIPDECOMP_RESULT_SUCCESS = 0,        ///< The operation completed successfully
+  HIPDECOMP_RESULT_INVALID_USAGE = 1,  ///< A user error, typically an invalid argument
+  HIPDECOMP_RESULT_NOT_SUPPORTED = 2,  ///< A user error, requesting an invalid or unsupported operation configuration
+  HIPDECOMP_RESULT_INTERNAL_ERROR = 3, ///< An internal library error, should be reported
+  HIPDECOMP_RESULT_HIP_ERROR = 4,      ///< An error occured in the HIP Runtime
+  HIPDECOMP_RESULT_HIPTENSOR_ERROR =
+      5,                           ///< An error occured in the hipTENSOR library (keeping for cuDecomp compatibility)
+  HIPDECOMP_RESULT_MPI_ERROR = 6,  ///< An error occurred in the MPI library
+  HIPDECOMP_RESULT_NCCL_ERROR = 7, ///< An error occured in the NCCL library
+  HIPDECOMP_RESULT_NVSHMEM_ERROR = 8, ///< An error occured in the NVSHMEM library
 } hipdecompResult_t;
 
 /**

--- a/include/internal/checks.h
+++ b/include/internal/checks.h
@@ -25,11 +25,6 @@
 
 #include <hip/hip_runtime.h>
 #include <hipfft/hipfft.h>
-#if HIP_VERSION_MAJOR < 7
-#include <hiptensor/hiptensor.hpp>
-#else
-#include <hiptensor/hiptensor.h>
-#endif
 #include <mpi.h>
 #include <rccl/rccl.h>
 
@@ -57,14 +52,6 @@
   do {                                                                                                                 \
     hipError_t err = hipGetLastError();                                                                                \
     if (hipSuccess != err) { throw hipdecomp::HipError(__FILE__, __LINE__, hipGetErrorString(err)); }                  \
-  } while (false)
-
-#define CHECK_HIPTENSOR(call)                                                                                          \
-  do {                                                                                                                 \
-    hiptensorStatus_t err = call;                                                                                      \
-    if (HIPTENSOR_STATUS_SUCCESS != err) {                                                                             \
-      throw hipdecomp::HiptensorError(__FILE__, __LINE__, hiptensorGetErrorString(err));                               \
-    }                                                                                                                  \
   } while (false)
 
 #define CHECK_NCCL(call)                                                                                               \

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -71,13 +71,6 @@ struct hipdecompHandle {
 
   std::vector<hipStream_t> streams; // internal streams for concurrent scheduling
 
-#if HIPTENSOR_MAJOR_VERSION >= 2
-  hiptensorHandle_t hiptensor_handle;            // hipTENSOR handle;
-  hiptensorPlanPreference_t hiptensor_plan_pref; // hipTENSOR plan preference;
-#else
-  hiptensorHandle_t* hiptensor_handle; // pointer to hipTENSOR handle;
-#endif
-
   std::vector<std::array<char, MPI_MAX_PROCESSOR_NAME>> hostnames; // list of hostnames by rank
   std::vector<int32_t> rank_to_local_rank;                         // list of local rank mappings
 

--- a/include/internal/exceptions.h
+++ b/include/internal/exceptions.h
@@ -42,10 +42,6 @@
   do {                                                                                                                 \
     throw hipdecomp::HipError(__FILE__, __LINE__, msg);                                                                \
   } while (false)
-#define THROW_HIPTENSOR_ERROR(msg)                                                                                     \
-  do {                                                                                                                 \
-    throw hipdecomp::HiptensorError(__FILE__, __LINE__, msg);                                                          \
-  } while (false)
 #define THROW_MPI_ERROR(msg)                                                                                           \
   do {                                                                                                                 \
     throw hipdecomp::MpiError(__FILE__, __LINE__, msg);                                                                \
@@ -108,13 +104,6 @@ public:
   HipError(const char* file, int line, const char* extra_info = nullptr)
       : BaseException(file, line, "HIP error.", extra_info) {};
   hipdecompResult_t getResult() const override { return HIPDECOMP_RESULT_HIP_ERROR; }
-};
-
-class HiptensorError : public BaseException {
-public:
-  HiptensorError(const char* file, int line, const char* extra_info = nullptr)
-      : BaseException(file, line, "hipTENSOR error.", extra_info) {};
-  hipdecompResult_t getResult() const override { return HIPDECOMP_RESULT_HIPTENSOR_ERROR; }
 };
 
 class MpiError : public BaseException {

--- a/include/internal/hipdecomp_kernels.h
+++ b/include/internal/hipdecomp_kernels.h
@@ -58,6 +58,20 @@ void hipdecomp_batched_d2d_memcpy_3d(hipdecompBatchedD2DMemcpy3DParams<std::comp
 void hipdecomp_batched_d2d_memcpy_3d(hipdecompBatchedD2DMemcpy3DParams<std::complex<double>>& params,
                                      hipStream_t stream);
 
+template <typename T> struct hipdecompPermuteD2DParams {
+  T* input;
+  T* output;
+  size_t extent_in[3];
+  size_t order_out[3];
+  size_t strides_in[3];
+  size_t strides_out[3];
+};
+
+void hipdecomp_permute_d2d(hipdecompPermuteD2DParams<float>& params, hipStream_t stream);
+void hipdecomp_permute_d2d(hipdecompPermuteD2DParams<double>& params, hipStream_t stream);
+void hipdecomp_permute_d2d(hipdecompPermuteD2DParams<std::complex<float>>& params, hipStream_t stream);
+void hipdecomp_permute_d2d(hipdecompPermuteD2DParams<std::complex<double>>& params, hipStream_t stream);
+
 } // namespace hipdecomp
 
 #endif // HIPDECOMP_KERNELS_H

--- a/include/internal/hipdecomp_kernels.hiph
+++ b/include/internal/hipdecomp_kernels.hiph
@@ -199,6 +199,33 @@ void hipdecomp_batched_d2d_memcpy_3d_nd_dispatch(const hipdecompBatchedD2DMemcpy
   CHECK_HIP_LAUNCH();
 }
 
+template <typename T> __global__ void hipdecomp_permute_d2d_k(hipdecompPermuteD2DParams<T> params, size_t size) {
+  const size_t idx = threadIdx.x + blockDim.x * blockIdx.x;
+  if (idx >= size) return;
+
+  size_t indices[3];
+  indices[0] = idx % params.extent_in[0];
+  indices[1] = (idx / params.extent_in[0]) % params.extent_in[1];
+  indices[2] = idx / (params.extent_in[0] * params.extent_in[1]);
+
+  const size_t input_idx =
+      indices[0] * params.strides_in[0] + indices[1] * params.strides_in[1] + indices[2] * params.strides_in[2];
+  const size_t output_idx = indices[params.order_out[0]] * params.strides_out[0] +
+                            indices[params.order_out[1]] * params.strides_out[1] +
+                            indices[params.order_out[2]] * params.strides_out[2];
+
+  params.output[output_idx] = params.input[input_idx];
+}
+
+template <typename T>
+void hipdecomp_permute_d2d_dispatch(const hipdecompPermuteD2DParams<T>& params, hipStream_t stream) {
+  const size_t size = params.extent_in[0] * params.extent_in[1] * params.extent_in[2];
+
+  hipdecomp_permute_d2d_k<<<(size + HIPDECOMP_HIP_NTHREADS - 1) / HIPDECOMP_HIP_NTHREADS, HIPDECOMP_HIP_NTHREADS, 0,
+                            stream>>>(params, size);
+  CHECK_HIP_LAUNCH();
+}
+
 } // namespace hipdecomp
 
 #endif // HIPDECOMP_KERNELS_CUH

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -25,11 +25,6 @@
 
 #include <complex>
 #include <hip/hip_runtime.h>
-#if HIP_VERSION_MAJOR < 7
-#include <hiptensor/hiptensor.hpp>
-#else
-#include <hiptensor/hiptensor.h>
-#endif
 #include <mpi.h>
 
 #include "internal/checks.h"
@@ -49,164 +44,24 @@ static inline bool isTransposeCommPipelined(hipdecompTransposeCommBackend_t comm
           commType == HIPDECOMP_TRANSPOSE_COMM_MPI_P2P_PL);
 }
 
-#if HIPTENSOR_MAJOR_VERSION >= 2
-static inline hiptensorDataType_t getHiptensorDataType(float) { return HIPTENSOR_R_32F; }
-static inline hiptensorDataType_t getHiptensorDataType(double) { return HIPTENSOR_R_64F; }
-static inline hiptensorDataType_t getHiptensorDataType(std::complex<float>) { return HIPTENSOR_C_32F; }
-static inline hiptensorDataType_t getHiptensorDataType(std::complex<double>) { return HIPTENSOR_C_64F; }
-template <typename T> static inline hiptensorDataType_t getHiptensorDataType() { return getHiptensorDataType(T(0)); }
-
-static inline hiptensorComputeDescriptor_t getHiptensorComputeType(hiptensorDataType_t hiptensor_dtype) {
-  switch (hiptensor_dtype) {
-  case HIPTENSOR_R_32F:
-  case HIPTENSOR_C_32F: return HIPTENSOR_COMPUTE_DESC_32F;
-  case HIPTENSOR_R_64F:
-  case HIPTENSOR_C_64F:
-  default: return HIPTENSOR_COMPUTE_DESC_64F;
-  }
-}
-
-template <typename T> static inline uint32_t getAlignment(const T* ptr) {
-  auto i_ptr = reinterpret_cast<std::uintptr_t>(ptr);
-  for (uint32_t d = 16; d > 0; d >>= 1) {
-    if (i_ptr % d == 0) return d;
-  }
-  return 1;
-}
-
 template <typename T>
-static void localPermute(const hipdecompHandle_t handle, const std::array<int64_t, 3>& extent_in,
-                         const std::array<int32_t, 3>& order_out, const std::array<int64_t, 3>& strides_in,
-                         const std::array<int64_t, 3>& strides_out, T* input, T* output, hipStream_t stream) {
-  // hipTensor only supports float for permutations
-  // handle this by adding an axis to the tensor that stays in place
-  // hiptensorDataType_t hiptensor_type = getHiptensorDataType<T>();
-  hiptensorDataType_t hiptensor_type = getHiptensorDataType<float>();
-
-  // Extend arrays from 3 to 4 dimensions
-  std::array<int32_t, 4> order_in_ext{0, 1, 2, 3};
-  std::array<int32_t, 4> order_out_ext;
-  std::array<int64_t, 4> extent_in_ext;
-  std::array<int64_t, 4> extent_out_ext;
-  std::array<int64_t, 4> strides_in_ext;
-  std::array<int64_t, 4> strides_out_ext;
-
-  const int num_extra = sizeof(T) / sizeof(float);
-
-  extent_in_ext[0] = num_extra;
-  order_out_ext[0] = 0;
-  strides_in_ext[0] = 1;
-  strides_out_ext[0] = 1;
+static void localPermute(const std::array<int64_t, 3>& extent_in, const std::array<int32_t, 3>& order_out,
+                         const std::array<int64_t, 3>& strides_in, const std::array<int64_t, 3>& strides_out, T* input,
+                         T* output, hipStream_t stream) {
+  hipdecompPermuteD2DParams<T> params;
+  params.input = input;
+  params.output = output;
 
   for (int i = 0; i < 3; ++i) {
-    extent_in_ext[i + 1] = extent_in[i];
-    // new axis is axis 0, so need to add one to each input value
-    order_out_ext[i + 1] = order_out[i] + 1;
-    // size of new axis is num_extra, so input strides have to be multiplied by this
-    strides_in_ext[i + 1] = strides_in[i] * num_extra;
-    strides_out_ext[i + 1] = strides_out[i] * num_extra;
+    if (extent_in[i] == 0) return;
+    params.extent_in[i] = extent_in[i];
+    params.order_out[i] = order_out[i];
+    params.strides_in[i] = strides_in[i];
+    params.strides_out[i] = strides_out[i];
   }
 
-  for (int i = 0; i < 4; ++i) {
-    extent_out_ext[i] = extent_in_ext[order_out_ext[i]];
-    if (extent_out_ext[i] == 0) return;
-  }
-
-  auto strides_in_ptr = anyNonzeros(strides_in_ext) ? strides_in_ext.data() : nullptr;
-  auto strides_out_ptr = anyNonzeros(strides_out_ext) ? strides_out_ext.data() : nullptr;
-
-  hiptensorTensorDescriptor_t desc_in;
-  CHECK_HIPTENSOR(hiptensorCreateTensorDescriptor(handle->hiptensor_handle, &desc_in, 4, extent_in_ext.data(),
-                                                  strides_in_ptr, hiptensor_type, getAlignment(input)));
-  hiptensorTensorDescriptor_t desc_out;
-  CHECK_HIPTENSOR(hiptensorCreateTensorDescriptor(handle->hiptensor_handle, &desc_out, 4, extent_out_ext.data(),
-                                                  strides_out_ptr, hiptensor_type, getAlignment(output)));
-
-  hiptensorOperationDescriptor_t desc_op;
-  CHECK_HIPTENSOR(hiptensorCreatePermutation(handle->hiptensor_handle, &desc_op, desc_in, order_in_ext.data(),
-                                             HIPTENSOR_OP_IDENTITY, desc_out, order_out_ext.data(),
-                                             getHiptensorComputeType(hiptensor_type)));
-
-  hiptensorPlan_t plan;
-  CHECK_HIPTENSOR(hiptensorCreatePlan(handle->hiptensor_handle, &plan, desc_op, handle->hiptensor_plan_pref, 0));
-
-  // scalar value must be of float type as we force hiptensor to run the computation in float.
-  // this works as long as the scalar value is one
-  // T one(1);
-  float one(1.0f);
-  CHECK_HIPTENSOR(hiptensorPermute(handle->hiptensor_handle, plan, &one, input, output, stream));
-
-  CHECK_HIPTENSOR(hiptensorDestroyTensorDescriptor(desc_in));
-  CHECK_HIPTENSOR(hiptensorDestroyTensorDescriptor(desc_out));
-  CHECK_HIPTENSOR(hiptensorDestroyOperationDescriptor(desc_op));
-  CHECK_HIPTENSOR(hiptensorDestroyPlan(plan));
+  hipdecomp_permute_d2d(params, stream);
 }
-
-#else
-
-static inline hipDataType getHipDataType(float) { return HIP_R_32F; }
-static inline hipDataType getHipDataType(double) { return HIP_R_64F; }
-static inline hipDataType getHipDataType(std::complex<float>) { return HIP_C_32F; }
-static inline hipDataType getHipDataType(std::complex<double>) { return HIP_C_64F; }
-template <typename T> static inline hipDataType getHipDataType() { return getHipDataType(T(0)); }
-
-template <typename T>
-static void localPermute(const hipdecompHandle_t handle, const std::array<int64_t, 3>& extent_in,
-                         const std::array<int32_t, 3>& order_out, const std::array<int64_t, 3>& strides_in,
-                         const std::array<int64_t, 3>& strides_out, T* input, T* output, hipStream_t stream) {
-  // hipTensor only supports float for permutations
-  // handle this by adding an axis to the tensor that stays in place
-  // hipDataType hip_type = getHipDataType<T>();
-  hipDataType hip_type = getHipDataType<float>();
-
-  // Extend arrays from 3 to 4 dimensions
-  std::array<int32_t, 4> order_in_ext{0, 1, 2, 3};
-  std::array<int32_t, 4> order_out_ext;
-  std::array<int64_t, 4> extent_in_ext;
-  std::array<int64_t, 4> extent_out_ext;
-  std::array<int64_t, 4> strides_in_ext;
-  std::array<int64_t, 4> strides_out_ext;
-
-  const int num_extra = sizeof(T) / sizeof(float);
-
-  extent_in_ext[0] = num_extra;
-  order_out_ext[0] = 0;
-  strides_in_ext[0] = 1;
-  strides_out_ext[0] = 1;
-
-  for (int i = 0; i < 3; ++i) {
-    extent_in_ext[i + 1] = extent_in[i];
-    // new axis is axis 0, so need to add one to each input value
-    order_out_ext[i + 1] = order_out[i] + 1;
-    // size of new axis is num_extra, so input strides have to be multiplied by this
-    strides_in_ext[i + 1] = strides_in[i] * num_extra;
-    strides_out_ext[i + 1] = strides_out[i] * num_extra;
-  }
-
-  for (int i = 0; i < 4; ++i) {
-    extent_out_ext[i] = extent_in_ext[order_out_ext[i]];
-    if (extent_out_ext[i] == 0) return;
-  }
-
-  auto strides_in_ptr = anyNonzeros(strides_in_ext) ? strides_in_ext.data() : nullptr;
-  auto strides_out_ptr = anyNonzeros(strides_out_ext) ? strides_out_ext.data() : nullptr;
-
-  hiptensorTensorDescriptor_t desc_in;
-  CHECK_HIPTENSOR(hiptensorInitTensorDescriptor(handle->hiptensor_handle, &desc_in, 4, extent_in_ext.data(),
-                                                strides_in_ptr, hip_type, HIPTENSOR_OP_IDENTITY));
-
-  hiptensorTensorDescriptor_t desc_out;
-  CHECK_HIPTENSOR(hiptensorInitTensorDescriptor(handle->hiptensor_handle, &desc_out, 4, extent_out_ext.data(),
-                                                strides_out_ptr, hip_type, HIPTENSOR_OP_IDENTITY));
-
-  // scalar value must be of float type as we force hiptensor to run the computation in float.
-  // this works as long as the scalar value is one
-  // T one(1);
-  float one(1.0f);
-  CHECK_HIPTENSOR(hiptensorPermutation(handle->hiptensor_handle, &one, input, &desc_in, order_in_ext.data(), output,
-                                       &desc_out, order_out_ext.data(), hip_type, stream));
-}
-#endif
 
 template <typename T>
 static void hipdecompTranspose_(int ax, int dir, const hipdecompHandle_t handle, const hipdecompGridDesc_t grid_desc,
@@ -483,7 +338,7 @@ static void hipdecompTranspose_(int ax, int dir, const hipdecompHandle_t handle,
               if (ax_a == pinfo_a.order[i]) extents[i] = splits_a[dst_rank];
             }
 
-            localPermute(handle, extents, order, strides_in, strides_out, src, dst, graph_stream);
+            localPermute(extents, order, strides_in, strides_out, src, dst, graph_stream);
 #if (HIP_VERSION_MAJOR >= 7) || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)
             hipStreamCaptureStatus capture_status;
             CHECK_HIP(hipStreamIsCapturing(graph_stream, &capture_status));
@@ -508,7 +363,7 @@ static void hipdecompTranspose_(int ax, int dir, const hipdecompHandle_t handle,
         } else {
           dst = o1 + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
         }
-        localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
+        localPermute(extents, order, strides_in, strides_out, src, dst, stream);
       }
 
       data_transposed = true;
@@ -720,7 +575,7 @@ static void hipdecompTranspose_(int ax, int dir, const hipdecompHandle_t handle,
               }
             }
 
-            localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
+            localPermute(extents, order, strides_in, strides_out, src, dst, stream);
           }
         }
       } else {
@@ -732,7 +587,7 @@ static void hipdecompTranspose_(int ax, int dir, const hipdecompHandle_t handle,
             src = o2 + getPencilPtrOffset(pinfo_a_h, input_halo_extents);
           }
           T* dst = o3 + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
-          localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
+          localPermute(extents, order, strides_in, strides_out, src, dst, stream);
         }
       }
     } else {
@@ -805,7 +660,7 @@ static void hipdecompTranspose_(int ax, int dir, const hipdecompHandle_t handle,
 
           T* src = o2 + recv_offsets[src_rank];
           T* dst = o3 + shift + getPencilPtrOffset(pinfo_b_h, output_halo_extents);
-          localPermute(handle, extents, order, strides_in, strides_out, src, dst, stream);
+          localPermute(extents, order, strides_in, strides_out, src, dst, stream);
         }
       }
     }

--- a/include/internal/transpose.h
+++ b/include/internal/transpose.h
@@ -484,9 +484,9 @@ static void hipdecompTranspose_(int ax, int dir, const hipdecompHandle_t handle,
             }
 
             localPermute(handle, extents, order, strides_in, strides_out, src, dst, graph_stream);
+#if (HIP_VERSION_MAJOR >= 7) || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)
             hipStreamCaptureStatus capture_status;
             CHECK_HIP(hipStreamIsCapturing(graph_stream, &capture_status));
-#if (HIP_VERSION_MAJOR >= 7) || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)
             CHECK_HIP(hipEventRecordWithFlags(grid_desc->events[dst_rank], graph_stream,
                                               capture_status == hipStreamCaptureStatusActive ? hipEventRecordExternal
                                                                                              : hipEventRecordDefault));
@@ -576,17 +576,17 @@ static void hipdecompTranspose_(int ax, int dir, const hipdecompHandle_t handle,
             hipdecomp_batched_d2d_memcpy_3d(memcpy_params, graph_stream);
             memcpy_count = 0;
           }
+#if (HIP_VERSION_MAJOR >= 7) || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)
           if (pipelined) {
             hipStreamCaptureStatus capture_status;
             CHECK_HIP(hipStreamIsCapturing(graph_stream, &capture_status));
-#if (HIP_VERSION_MAJOR >= 7) || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 4)
             CHECK_HIP(hipEventRecordWithFlags(grid_desc->events[dst_rank], graph_stream,
                                               capture_status == hipStreamCaptureStatusActive ? hipEventRecordExternal
                                                                                              : hipEventRecordDefault));
-#else
-            CHECK_HIP(hipEventRecord(grid_desc->events[dst_rank], graph_stream));
-#endif
           }
+#else
+          if (pipelined) CHECK_HIP(hipEventRecord(grid_desc->events[dst_rank], graph_stream));
+#endif
         }
         if (handle->hip_graphs_enable && pipelined && splits_a.size() > 1) {
           grid_desc->graph_cache.endCapture(key);

--- a/src/hipdecomp.cc
+++ b/src/hipdecomp.cc
@@ -318,13 +318,6 @@ hipdecompResult_t hipdecompInit(hipdecompHandle_t* handle_in, MPI_Comm mpi_comm)
     CHECK_MPI(MPI_Comm_rank(handle->mpi_local_comm, &handle->local_rank));
     CHECK_MPI(MPI_Comm_size(handle->mpi_local_comm, &handle->local_nranks));
 
-    // Initialize hipTENSOR library
-    CHECK_HIPTENSOR(hiptensorCreate(&handle->hiptensor_handle));
-#if HIPTENSOR_MAJOR_VERSION >= 2
-    CHECK_HIPTENSOR(hiptensorCreatePlanPreference(handle->hiptensor_handle, &handle->hiptensor_plan_pref,
-                                                  HIPTENSOR_ALGO_DEFAULT, HIPTENSOR_JIT_MODE_NONE));
-#endif
-
     // Gather hipDecomp environment variable settings
     getHipdecompEnvVars(handle);
 
@@ -364,11 +357,6 @@ hipdecompResult_t hipdecompFinalize(hipdecompHandle_t handle) {
     }
 #endif
     CHECK_MPI(MPI_Comm_free(&handle->mpi_local_comm));
-
-    CHECK_HIPTENSOR(hiptensorDestroy(handle->hiptensor_handle));
-#if HIPTENSOR_MAJOR_VERSION >= 2
-    CHECK_HIPTENSOR(hiptensorDestroyPlanPreference(handle->hiptensor_plan_pref));
-#endif
 
     handle = nullptr;
     delete handle;

--- a/src/hipdecomp_kernels.hip
+++ b/src/hipdecomp_kernels.hip
@@ -38,4 +38,20 @@ void hipdecomp_batched_d2d_memcpy_3d(hipdecompBatchedD2DMemcpy3DParams<std::comp
   hipdecomp_batched_d2d_memcpy_3d_nd_dispatch(params, stream);
 }
 
+void hipdecomp_permute_d2d(hipdecompPermuteD2DParams<float>& params, hipStream_t stream) {
+  hipdecomp_permute_d2d_dispatch(params, stream);
+}
+
+void hipdecomp_permute_d2d(hipdecompPermuteD2DParams<double>& params, hipStream_t stream) {
+  hipdecomp_permute_d2d_dispatch(params, stream);
+}
+
+void hipdecomp_permute_d2d(hipdecompPermuteD2DParams<std::complex<float>>& params, hipStream_t stream) {
+  hipdecomp_permute_d2d_dispatch(params, stream);
+}
+
+void hipdecomp_permute_d2d(hipdecompPermuteD2DParams<std::complex<double>>& params, hipStream_t stream) {
+  hipdecomp_permute_d2d_dispatch(params, stream);
+}
+
 } // namespace hipdecomp


### PR DESCRIPTION
`hiptensorPermute` does not respect output strides; it always writes values contiguously.

If we need to fix this with a kernel anyway, we might as well replace the entire hiptensor call with a custom kernel.
This is the only place hipTensor was used, hence it is removed entirely as a dependency.

This can be revisited then the stride support is fixed, and preferably when types other than `float` are supported as well.