### PR TITLE
Fix Fortran halo tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,12 +62,12 @@ jobs:
       - name: Run Fortran halo tests
         run: |
           cd build/tests
-          python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 4" --config_overrides "backend:[1,2]" halo_test_fortran  # disable NCCL/NVSHMEM backends
-          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 4" halo_test_halomix_fortran
-          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 4" halo_test_padding_fortran
-          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 4" halo_test_gdimdist_fortran
-          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 4" halo_test_mix_fortran
-          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 4" halo_test_ac_fortran
+          python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 2" --config_overrides "backend:[1,2]" halo_test_fortran  # disable NCCL/NVSHMEM backends
+          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 2" halo_test_halomix_fortran
+          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 2" halo_test_padding_fortran
+          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 2" halo_test_gdimdist_fortran
+          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 2" halo_test_mix_fortran
+          # python3 test_runner.py --ngpu 2 --exit_on_failure --launcher_cmd "mpirun -n 2" halo_test_ac_fortran
 
       - name: Run C++ examples
         run: |


### PR DESCRIPTION
Accidentally had non-matching number of MPI ranks and number of GPUs in the command line.